### PR TITLE
fixed the bug

### DIFF
--- a/pages/compare.py
+++ b/pages/compare.py
@@ -23,6 +23,9 @@ st.set_page_config(layout="wide")
 ClarifaiStreamlitCSS.insert_default_css(st)
 
 
+if 'generated_completions' not in st.session_state:
+  st.session_state['generated_completions'] = False
+
 def local_css(file_name):
   with open(file_name) as f:
     st.markdown("<style>{}</style>".format(f.read()), unsafe_allow_html=True)
@@ -562,7 +565,11 @@ def render_card(container, input, caller_id, completions):
     container.code(d['completion'], language=None)
 
 
-if st.button("Generate Completions"):
+generate_btn = st.button("Generate Completions")
+if generate_btn:
+  st.session_state['generated_completions'] = True
+
+if st.session_state['generated_completions']:
 
   if inp and models:
     if len(models) == 0:


### PR DESCRIPTION
https://clarifai.atlassian.net/browse/TT-2946

When we select/deselect checkbox in the model response table, in order to compare responses of 2 models side-by-side, the page reloads and the responses are lost.
Should be fixed before the blog is posted.
![image](https://github.com/Clarifai/module-llm-battleground/assets/20639882/1420ef8b-1f20-47b9-b61a-583ade9168e2)
